### PR TITLE
Merge upstream updates to dropzonejs to version 2.4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# @see http://editorconfig.org/
+
+[composer.libraries.json]
+indent_size = 4
+indent_style = space

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,3 +1,0 @@
-# Developing
-
-* Pull requests can be made against https://github.com/drupal-media/dropzonejs/pulls

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-## About DropzoneJS
+# About DropzoneJS
 
 This is the Drupal integration for [DropzoneJS](http://www.dropzonejs.com/).
 
-###How to install:
+### How to install
+
+#### The non-composer way
+
 1. Download this module
 2. [Download DropzoneJS](https://github.com/enyo/dropzone) and place it in the
    libraries folder
@@ -12,25 +15,68 @@ This is the Drupal integration for [DropzoneJS](http://www.dropzonejs.com/).
 
 You will now have a dropzonejs element at your disposal.
 
-###Future plans:
+#### The composer way 1
+
+Run `composer require wikimedia/composer-merge-plugin`
+
+Update the root `composer.json` file. For example:
+
+```
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "web/modules/contrib/dropzonejs/composer.libraries.json"
+            ]
+        }
+    }
+```
+
+Run `composer require drupal/dropzonejs enyo/dropzone`, the DropzoneJS library will be
+installed to the `libraries` folder automatically.
+
+#### The composer way 2
+
+Copy the following into the root `composer.json` file's `repository` key
+
+```
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "enyo/dropzone",
+                "version": "5.7.1",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://github.com/enyo/dropzone/archive/v5.7.1.zip",
+                    "type": "zip"
+                }
+            }
+        }
+    ]
+```
+
+Run `composer require drupal/dropzonejs enyo/dropzone`, the DropzoneJS library
+will be installed to the `libraries` folder automatically as well.
+
+### Future plans:
 - A dropzonejs field widget.
 - Handling already uploaded files.
 - Handling other types of upload validations (min/max resolution, min size,...)
 - Removing files that were removed by the user on first upload from temp storage.
 
-###Project page:
+### Project page:
 [drupal.org project page](https://www.drupal.org/project/dropzonejs)
 
-###Maintainers:
+### Maintainers:
 + Janez Urevc (@slashrsm) drupal.org/u/slashrsm
 + John McCormick (@neardark) drupal.org/u/neardark
 + Primoz Hmeljak (@primsi) drupal.org/u/Primsi
 + Qiangjun Ran (@jungle) drupal.org/u/jungle
 
-###Get in touch:
+### Get in touch:
  - http://groups.drupal.org/media
  - **#media**: http://drupal.slack.com
 
-###Thanks:
+### Thanks:
  The development of this module is sponsored by [Examiner.com](http://www.examiner.com)
  Thanks also to [NYC CAMP](http://nyccamp.org/) that hosted media sprints.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## About DropzoneJS
 
-This is the Drupal 8 integration for [DropzoneJS](http://www.dropzonejs.com/).
+This is the Drupal integration for [DropzoneJS](http://www.dropzonejs.com/).
 
 ###How to install:
 1. Download this module
 2. [Download DropzoneJS](https://github.com/enyo/dropzone) and place it in the
    libraries folder
-3. Install dropzonejs the [usual way](https://www.drupal.org/documentation/install/modules-themes/modules-8)
+3. Install dropzonejs the [usual way](https://www.drupal.org/docs/extending-drupal/installing-drupal-modules)
 4. Remove "test" folder from libraries folder as it could constitute a
    security risk to your site. See http://drupal.org/node/1189632 for more info.
 
@@ -25,11 +25,12 @@ You will now have a dropzonejs element at your disposal.
 + Janez Urevc (@slashrsm) drupal.org/u/slashrsm
 + John McCormick (@neardark) drupal.org/u/neardark
 + Primoz Hmeljak (@primsi) drupal.org/u/Primsi
++ Qiangjun Ran (@jungle) drupal.org/u/jungle
 
 ###Get in touch:
  - http://groups.drupal.org/media
- - IRC: #drupal-media @ Freenode
- 
+ - **#media**: http://drupal.slack.com
+
 ###Thanks:
  The development of this module is sponsored by [Examiner.com](http://www.examiner.com)
  Thanks also to [NYC CAMP](http://nyccamp.org/) that hosted media sprints.

--- a/composer.json
+++ b/composer.json
@@ -1,41 +1,49 @@
 {
-  "name": "drupal/dropzonejs",
-  "description": "Drupal integration for DropzoneJS - An open source library that provides drag’n’drop file uploads with image previews.",
-  "type": "drupal-module",
-  "homepage": "https://www.drupal.org/project/dropzonejs",
-  "keywords": ["Drupal", "DropzoneJS"],
-  "license": "GPL-2.0+",
-  "minimum-stability": "dev",
-  "prefer-stable": true,
-  "support": {
-    "issues": "https://www.drupal.org/project/issues/dropzonejs",
-    "irc": "irc://irc.freenode.org/drupal-contribute",
-    "source": "https://www.drupal.org/project/dropzonejs"
-  },
-  "authors": [
-    {
-      "name": "Janez Urevc",
-      "homepage": "https://drupal.org/u/slashrsm",
-      "role": "Maintainer"
+    "name": "drupal/dropzonejs",
+    "description": "Drupal integration for DropzoneJS - An open source library that provides drag’n’drop file uploads with image previews.",
+    "type": "drupal-module",
+    "homepage": "https://www.drupal.org/project/dropzonejs",
+    "keywords": ["Drupal", "DropzoneJS"],
+    "license": "GPL-2.0-or-later",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "support": {
+        "issues": "https://www.drupal.org/project/issues/dropzonejs",
+        "#media": "http://drupal.slack.com",
+        "source": "https://www.drupal.org/project/dropzonejs"
     },
-    {
-      "name": "Christian Fritsch",
-      "homepage": "https://drupal.org/u/chrfritsch",
-      "role": "Maintainer"
+    "authors": [
+        {
+            "name": "Janez Urevc",
+            "homepage": "https://drupal.org/u/slashrsm",
+            "role": "Maintainer"
+        },
+        {
+            "name": "Christian Fritsch",
+            "homepage": "https://drupal.org/u/chrfritsch",
+            "role": "Maintainer"
+        },
+        {
+            "name": "Primoz Hmeljak",
+            "homepage": "https://drupal.org/u/Primsi",
+            "role": "Maintainer"
+        },
+        {
+            "name": "Qiangjun Ran",
+            "homepage": "https://drupal.org/u/jungle",
+            "role": "Maintainer"
+        },
+        {
+            "name": "See other contributors",
+            "homepage": "https://www.drupal.org/node/1998478/committers",
+            "role": "contributor"
+        }
+    ],
+    "require": {},
+    "require-dev": {
+        "drupal/entity_browser": "^2.5"
     },
-    {
-      "name": "Primoz Hmeljak",
-      "homepage": "https://drupal.org/u/Primsi",
-      "role": "Maintainer"
-    },
-    {
-      "name": "See other contributors",
-      "homepage": "https://www.drupal.org/node/1998478/committers",
-      "role": "contributor"
+    "suggest": {
+        "enyo/dropzone": "Required to use drupal/dropzonejs. DropzoneJS is an open source library that provides drag’n’drop file uploads with image previews."
     }
-  ],
-  "require": {},
-  "suggest": {
-    "enyo/dropzone": "Required to user drupal/dropzonejs. Dropzone is an easy to use drag'n'drop library."
-  }
 }

--- a/composer.libraries.json
+++ b/composer.libraries.json
@@ -1,0 +1,19 @@
+{
+    "repositories": {
+        "enyo/dropzone": {
+            "type": "package",
+            "package": {
+                "name": "enyo/dropzone",
+                "version": "5.7.1",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://github.com/enyo/dropzone/archive/v5.7.1.zip",
+                    "type": "zip"
+                }
+            }
+        }
+    },
+    "require": {
+        "enyo/dropzone": "5.7.1"
+    }
+}

--- a/composer.libraries.json
+++ b/composer.libraries.json
@@ -4,16 +4,16 @@
             "type": "package",
             "package": {
                 "name": "enyo/dropzone",
-                "version": "5.7.1",
+                "version": "5.7.2",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/enyo/dropzone/archive/v5.7.1.zip",
+                    "url": "https://github.com/enyo/dropzone/archive/v5.7.2.zip",
                     "type": "zip"
                 }
             }
         }
     },
     "require": {
-        "enyo/dropzone": "5.7.1"
+        "enyo/dropzone": "5.7.2"
     }
 }

--- a/config/install/dropzonejs.settings.yml
+++ b/config/install/dropzonejs.settings.yml
@@ -1,1 +1,2 @@
 tmp_upload_scheme: temporary
+filename_transliteration: true

--- a/config/install/dropzonejs.settings.yml
+++ b/config/install/dropzonejs.settings.yml
@@ -1,2 +1,3 @@
 tmp_upload_scheme: temporary
 filename_transliteration: true
+upload_timeout_ms: 0

--- a/config/schema/dropzonejs.schema.yml
+++ b/config/schema/dropzonejs.schema.yml
@@ -5,3 +5,6 @@ dropzonejs.settings:
     tmp_upload_scheme:
       type: string
       label: 'Upload scheme'
+    filename_transliteration:
+      type: boolean
+      label: 'Transliterate names of uploaded files'

--- a/config/schema/dropzonejs.schema.yml
+++ b/config/schema/dropzonejs.schema.yml
@@ -8,3 +8,6 @@ dropzonejs.settings:
     filename_transliteration:
       type: boolean
       label: 'Transliterate names of uploaded files'
+    upload_timeout_ms:
+      type: integer
+      label: 'Upload timeout'

--- a/dropzonejs.info.yml
+++ b/dropzonejs.info.yml
@@ -1,6 +1,6 @@
 name: dropzonejs
 type: module
-description: DropzoneJS
+description: The Drupal integration for DropzoneJS.
 core_version_requirement: ^8.8 || ^9
 package: Media
 dependencies:

--- a/dropzonejs.info.yml
+++ b/dropzonejs.info.yml
@@ -1,7 +1,7 @@
 name: dropzonejs
 type: module
 description: DropzoneJS
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Media
 dependencies:
   - drupal:file

--- a/dropzonejs.install
+++ b/dropzonejs.install
@@ -22,7 +22,7 @@ function dropzonejs_requirements($phase) {
 
   // If library is not found, then look in the current profile libraries path.
   if (!$library_found) {
-    $profile_path = drupal_get_path('profile', drupal_get_profile());
+    $profile_path = drupal_get_path('profile', \Drupal::installProfile());
     $profile_path .= '/libraries/dropzone/dist/min/dropzone.min.js';
     // Is the library found in the current profile libraries path.
     $library_found = file_exists($profile_path);

--- a/dropzonejs.install
+++ b/dropzonejs.install
@@ -72,3 +72,14 @@ function dropzonejs_update_8002() {
   $config->set('filename_transliteration', TRUE);
   $config->save(TRUE);
 }
+
+/**
+ * Set default value for upload timeout.
+ */
+function dropzonejs_update_8003() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('dropzonejs.settings');
+  $config->clear('upload_timeout_ms');
+  $config->set('upload_timeout_ms', 0);
+  $config->save(TRUE);
+}

--- a/dropzonejs.install
+++ b/dropzonejs.install
@@ -12,20 +12,30 @@ function dropzonejs_requirements($phase) {
 
   $requirements = [];
 
-  $path = DRUPAL_ROOT . '/libraries/dropzone/dist/min/dropzone.min.js';
-  if (\Drupal::moduleHandler()->moduleExists('libraries')) {
-    $path = libraries_get_path('dropzone') . '/dist/min/dropzone.min.js';
+  // @todo Remove this conditional structure in favor of using the libraries
+  // directory file finder service when Drupal 8.9 is the minimum supported
+  // version of core.
+  if (\Drupal::hasService('library.libraries_directory_file_finder')) {
+    /** @var \Drupal\Core\Asset\LibrariesDirectoryFileFinder $library_file_finder */
+    $library_file_finder = \Drupal::service('library.libraries_directory_file_finder');
+    $library_found = (bool) $library_file_finder->find('dropzone/dist/min/dropzone.min.js');
   }
+  else {
+    $path = DRUPAL_ROOT . '/libraries/dropzone/dist/min/dropzone.min.js';
+    if (\Drupal::moduleHandler()->moduleExists('libraries')) {
+      $path = libraries_get_path('dropzone') . '/dist/min/dropzone.min.js';
+    }
 
-  // Is the library found in the root libraries path.
-  $library_found = file_exists($path);
+    // Is the library found in the root libraries path.
+    $library_found = file_exists($path);
 
-  // If library is not found, then look in the current profile libraries path.
-  if (!$library_found) {
-    $profile_path = drupal_get_path('profile', \Drupal::installProfile());
-    $profile_path .= '/libraries/dropzone/dist/min/dropzone.min.js';
-    // Is the library found in the current profile libraries path.
-    $library_found = file_exists($profile_path);
+    // If library is not found, then look in the current profile libraries path.
+    if (!$library_found) {
+      $profile_path = drupal_get_path('profile', \Drupal::installProfile());
+      $profile_path .= '/libraries/dropzone/dist/min/dropzone.min.js';
+      // Is the library found in the current profile libraries path.
+      $library_found = file_exists($profile_path);
+    }
   }
 
   if (!$library_found) {

--- a/dropzonejs.install
+++ b/dropzonejs.install
@@ -51,3 +51,14 @@ function dropzonejs_update_8001() {
   $config->set('tmp_upload_scheme', 'temporary');
   $config->save(TRUE);
 }
+
+/**
+ * Set default value for transliterate file name.
+ */
+function dropzonejs_update_8002() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('dropzonejs.settings');
+  $config->clear('filename_transliteration');
+  $config->set('filename_transliteration', TRUE);
+  $config->save(TRUE);
+}

--- a/dropzonejs.libraries.yml
+++ b/dropzonejs.libraries.yml
@@ -7,10 +7,10 @@ dropzonejs:
     url: https://github.com/enyo/dropzone/blob/master/LICENSE
     gpl-compatible: true
   js:
-    /libraries/dropzone/dist/min/dropzone.min.js: {}
+    /libraries/dropzone/dist/min/dropzone.min.js: { minified: true }
   css:
     component:
-      /libraries/dropzone/dist/min/dropzone.min.css: {}
+      /libraries/dropzone/dist/min/dropzone.min.css: { minified: true }
 widget:
   version: VERSION
   css:

--- a/dropzonejs.libraries.yml
+++ b/dropzonejs.libraries.yml
@@ -1,7 +1,7 @@
 dropzonejs:
   title: 'Dropzonejs'
   website: http://www.dropzonejs.com
-  version: 4.0.1
+  version: 5.7.2
   license:
     name: MIT
     url: https://github.com/enyo/dropzone/blob/master/LICENSE

--- a/dropzonejs.module
+++ b/dropzonejs.module
@@ -65,14 +65,22 @@ function template_preprocess_dropzonejs(array &$variables) {
 function dropzonejs_library_info_build() {
   $libraries = [];
 
-  if (\Drupal::moduleHandler()->moduleExists('libraries')) {
+  // @todo Remove this conditional structure in favor of using the libraries
+  // directory file finder service when Drupal 8.9 is the minimum supported
+  // version of core.
+  if (\Drupal::hasService('library.libraries_directory_file_finder')) {
+    /** @var \Drupal\Core\Asset\LibrariesDirectoryFileFinder $library_file_finder */
+    $library_file_finder = \Drupal::service('library.libraries_directory_file_finder');
+    $exif_path = $library_file_finder->find('exif-js/exif.js');
+  }
+  elseif (\Drupal::moduleHandler()->moduleExists('libraries')) {
     $exif_path = libraries_get_path('exif-js') . '/exif.js';
   }
   else {
     $exif_path = DRUPAL_ROOT . '/libraries/exif-js/exif.js';
   }
 
-  if ($exif_found = file_exists($exif_path)) {
+  if ($exif_path && file_exists($exif_path)) {
     $libraries['exif-js'] = [
       'title' => 'Exif',
       'website' => 'https://github.com/exif-js/exif-js',

--- a/dropzonejs.services.yml
+++ b/dropzonejs.services.yml
@@ -1,7 +1,7 @@
 services:
   dropzonejs.upload_save:
     class: Drupal\dropzonejs\DropzoneJsUploadSave
-    arguments: ['@entity.manager', '@file.mime_type.guesser', '@file_system', '@logger.factory', '@renderer', '@config.factory', '@token']
+    arguments: ['@entity.manager', '@file.mime_type.guesser', '@file_system', '@logger.factory', '@renderer', '@config.factory', '@token', '@messenger']
   dropzonejs.upload_handler:
     class: Drupal\dropzonejs\UploadHandler
     arguments: ['@request_stack', '@config.factory', '@transliteration', '@language_manager']

--- a/dropzonejs.services.yml
+++ b/dropzonejs.services.yml
@@ -1,7 +1,7 @@
 services:
   dropzonejs.upload_save:
     class: Drupal\dropzonejs\DropzoneJsUploadSave
-    arguments: ['@entity_type.manager', '@file.mime_type.guesser', '@file_system', '@logger.factory', '@renderer', '@config.factory', '@token', '@messenger']
+    arguments: ['@entity_type.manager', '@file.mime_type.guesser', '@file_system', '@logger.factory', '@renderer', '@config.factory', '@token', '@messenger', '@stream_wrapper_manager']
   dropzonejs.upload_handler:
     class: Drupal\dropzonejs\UploadHandler
     arguments: ['@request_stack', '@config.factory', '@transliteration', '@language_manager']

--- a/dropzonejs.services.yml
+++ b/dropzonejs.services.yml
@@ -1,7 +1,7 @@
 services:
   dropzonejs.upload_save:
     class: Drupal\dropzonejs\DropzoneJsUploadSave
-    arguments: ['@entity.manager', '@file.mime_type.guesser', '@file_system', '@logger.factory', '@renderer', '@config.factory', '@token', '@messenger']
+    arguments: ['@entity_type.manager', '@file.mime_type.guesser', '@file_system', '@logger.factory', '@renderer', '@config.factory', '@token', '@messenger']
   dropzonejs.upload_handler:
     class: Drupal\dropzonejs\UploadHandler
     arguments: ['@request_stack', '@config.factory', '@transliteration', '@language_manager']

--- a/drupalci.yml
+++ b/drupalci.yml
@@ -1,0 +1,66 @@
+# This is the DrupalCI testbot build file for Drupal core.
+# Learn to make one for your own drupal.org project:
+# https://www.drupal.org/drupalorg/docs/drupal-ci/customizing-drupalci-testing
+build:
+  assessment:
+    validate_codebase:
+      phplint:
+      csslint:
+        halt-on-fail: false
+      eslint:
+        # A test must pass eslinting standards check in order to continue processing.
+        halt-on-fail: false
+      phpcs:
+        # phpcs will use core's specified version of Coder.
+        sniff-all-files: false
+        halt-on-fail: false
+    testing:
+      container_command:
+        commands: "cd ${SOURCE_DIR} &&
+        sudo -u www-data mkdir libraries &&
+        sudo -u www-data curl https://codeload.github.com/enyo/dropzone/tar.gz/v5.5.0 --output dropzone.tar.gz --silent &&
+        sudo -u www-data tar xzf dropzone.tar.gz &&
+        sudo -u www-data mv dropzone-5.5.0 libraries/dropzone"
+        halt-on-fail: true
+      # run_tests task is executed several times in order of performance speeds.
+      # halt-on-fail can be set on the run_tests tasks in order to fail fast.
+      # suppress-deprecations is false in order to be alerted to usages of
+      # deprecated code.
+      run_tests.phpunit:
+        types: 'PHPUnit-Unit'
+        testgroups: '--all'
+        suppress-deprecations: true
+        halt-on-fail: false
+      run_tests.kernel:
+        types: 'PHPUnit-Kernel'
+        testgroups: '--all'
+        suppress-deprecations: true
+        halt-on-fail: false
+      run_tests.simpletest:
+        types: 'Simpletest'
+        testgroups: '--all'
+        suppress-deprecations: true
+        halt-on-fail: false
+      run_tests.build:
+        types: 'PHPUnit-Build'
+        testgroups: '--all'
+        suppress-deprecations: true
+        halt-on-fail: false
+      run_tests.functional:
+        types: 'PHPUnit-Functional'
+        testgroups: '--all'
+        suppress-deprecations: true
+        halt-on-fail: false
+      run_tests.javascript:
+        concurrency: 15
+        types: 'PHPUnit-FunctionalJavascript'
+        testgroups: '--all'
+        suppress-deprecations: true
+        halt-on-fail: false
+      # Run nightwatch testing.
+      # @see https://www.drupal.org/project/drupal/issues/2869825
+      nightwatchjs:
+#      container_command.drupal_project_templates:
+#        commands:
+#          - "sudo -u www-data ${SOURCE_DIR}/core/tests/scripts/test_composer_project_templates.sh"
+#        halt-on-fail: true

--- a/drupalci.yml
+++ b/drupalci.yml
@@ -15,11 +15,12 @@ build:
         halt-on-fail: false
     testing:
       container_command:
-        commands: "cd ${SOURCE_DIR} &&
-        sudo -u www-data mkdir libraries &&
-        sudo -u www-data curl https://codeload.github.com/enyo/dropzone/tar.gz/v5.5.0 --output dropzone.tar.gz --silent &&
-        sudo -u www-data tar xzf dropzone.tar.gz &&
-        sudo -u www-data mv dropzone-5.5.0 libraries/dropzone"
+        commands:
+         - "cd ${SOURCE_DIR}"
+         - "sudo -u www-data mkdir libraries"
+         - "sudo -u www-data curl https://codeload.github.com/enyo/dropzone/tar.gz/v5.5.0 --output dropzone.tar.gz --silent"
+         - "sudo -u www-data tar xzf dropzone.tar.gz"
+         - "sudo -u www-data mv dropzone-5.5.0 libraries/dropzone"
         halt-on-fail: true
       # run_tests task is executed several times in order of performance speeds.
       # halt-on-fail can be set on the run_tests tasks in order to fail fast.

--- a/drupalci.yml
+++ b/drupalci.yml
@@ -1,5 +1,4 @@
 # This is the DrupalCI testbot build file for Drupal core.
-# Learn to make one for your own drupal.org project:
 # https://www.drupal.org/drupalorg/docs/drupal-ci/customizing-drupalci-testing
 build:
   assessment:

--- a/js/dropzone.integration.js
+++ b/js/dropzone.integration.js
@@ -25,7 +25,24 @@
         // Initiate dropzonejs.
         var config = {
           url: input.attr('data-upload-path'),
-          addRemoveLinks: false
+          addRemoveLinks: false,
+          dictDefaultMessage: Drupal.t('Drop files here to upload'),
+          dictFallbackMessage: Drupal.t('Your browser does not support drag\'n\'drop file uploads.'),
+          dictFallbackText: Drupal.t('Please use the fallback form below to upload your files like in the olden days.'),
+          dictFileTooBig: Drupal.t('File is too big ({{filesize}}MiB). Max filesize: {{maxFilesize}}MiB.'),
+          dictInvalidFileType: Drupal.t('You can\'t upload files of this type.'),
+          dictResponseError: Drupal.t('Server responded with {{statusCode}} code.'),
+          dictCancelUpload: Drupal.t('Cancel upload'),
+          dictCancelUploadConfirmation: Drupal.t('Are you sure you want to cancel this upload?'),
+          dictRemoveFile: Drupal.t('Remove file'),
+          dictMaxFilesExceeded: Drupal.t('You can not upload any more files.'),
+          dictFileSizeUnits: {
+            tb: Drupal.t('TB'),
+            gb: Drupal.t('GB'),
+            mb: Drupal.t('MB'),
+            kb: Drupal.t('KB'),
+            b: Drupal.t('b')
+          },
         };
         var instanceConfig = drupalSettings.dropzonejs.instances[selector.attr('id')];
 

--- a/js/dropzone.integration.js
+++ b/js/dropzone.integration.js
@@ -15,82 +15,85 @@
     attach: function (context) {
       Dropzone.autoDiscover = false;
 
-      // @todo Init functionality should support multiple drop zones on page.
-      var selector = $('.dropzone-enable');
-      selector.addClass('dropzone');
-      var input = selector.siblings('input');
+      $('.dropzone-enable').each(function() {
+        var selector = $(this);
+        selector.addClass('dropzone');
 
-      // Initiate dropzonejs.
-      var config = {
-        url: input.attr('data-upload-path'),
-        addRemoveLinks: false
-      };
-      var instanceConfig = drupalSettings.dropzonejs.instances[selector.attr('id')];
+        // selector.addClass('dropzone');
+        var input = selector.siblings('input');
 
-      // If DropzoneJS instance is already registered on Element. There is no
-      // need to register it again.
-      if (selector.once('register-dropzonejs').length !== selector.length) {
-        return;
-      }
+        // Initiate dropzonejs.
+        var config = {
+          url: input.attr('data-upload-path'),
+          addRemoveLinks: false
+        };
+        var instanceConfig = drupalSettings.dropzonejs.instances[selector.attr('id')];
 
-      // If instance exists for configuration, but it's detached from element
-      // then destroy detached instance and create new instance.
-      if (instanceConfig.instance !== void 0) {
-        instanceConfig.instance.destroy();
-      }
+        // If DropzoneJS instance is already registered on Element. There is no
+        // need to register it again.
+        if (selector.once('register-dropzonejs').length !== selector.length) {
+          return;
+        }
 
-      // Initialize DropzoneJS instance for element.
-      var dropzoneInstance = new Dropzone('#' + selector.attr('id'), $.extend({}, instanceConfig, config));
+        // If instance exists for configuration, but it's detached from element
+        // then destroy detached instance and create new instance.
+        if (instanceConfig.instance !== void 0) {
+          instanceConfig.instance.destroy();
+        }
 
-      // Other modules might need instances.
-      drupalSettings['dropzonejs']['instances'][selector.attr('id')]['instance'] = dropzoneInstance;
+        // Initialize DropzoneJS instance for element.
+        var dropzoneInstance = new Dropzone('#' + selector.attr('id'), $.extend({}, instanceConfig, config));
 
-      dropzoneInstance.on('addedfile', function (file) {
-        file._removeIcon = Dropzone.createElement("<div class='dropzonejs-remove-icon' title='Remove'></div>");
-        file.previewElement.appendChild(file._removeIcon);
-        file._removeIcon.addEventListener('click', function () {
-          dropzoneInstance.removeFile(file);
+        // Other modules might need instances.
+        drupalSettings['dropzonejs']['instances'][selector.attr('id')]['instance'] = dropzoneInstance;
+
+        dropzoneInstance.on('addedfile', function (file) {
+          file._removeIcon = Dropzone.createElement("<div class='dropzonejs-remove-icon' title='Remove'></div>");
+          file.previewElement.appendChild(file._removeIcon);
+          file._removeIcon.addEventListener('click', function () {
+            dropzoneInstance.removeFile(file);
+          });
         });
-      });
 
-      // React on add file. Add only accepted files.
-      dropzoneInstance.on('success', function (file, response) {
-        var uploadedFilesElement = selector.siblings(':hidden');
-        var currentValue = uploadedFilesElement.attr('value') || '';
+        // React on add file. Add only accepted files.
+        dropzoneInstance.on('success', function (file, response) {
+          var uploadedFilesElement = selector.siblings(':hidden');
+          var currentValue = uploadedFilesElement.attr('value') || '';
 
-        // The file is transliterated on upload. The element has to reflect
-        // the real filename.
-        file.processedName = response.result;
+          // The file is transliterated on upload. The element has to reflect
+          // the real filename.
+          file.processedName = response.result;
 
-        uploadedFilesElement.attr('value', currentValue + response.result + ';');
-      });
+          uploadedFilesElement.attr('value', currentValue + response.result + ';');
+        });
 
-      // React on file removing.
-      dropzoneInstance.on('removedfile', function (file) {
-        var uploadedFilesElement = selector.siblings(':hidden');
-        var currentValue = uploadedFilesElement.attr('value');
+        // React on file removing.
+        dropzoneInstance.on('removedfile', function (file) {
+          var uploadedFilesElement = selector.siblings(':hidden');
+          var currentValue = uploadedFilesElement.attr('value');
 
-        // Remove the file from the element.
-        if (currentValue.length) {
-          var fileNames = currentValue.split(';');
-          for (var i in fileNames) {
-            if (fileNames[i] === file.processedName) {
-              fileNames.splice(i, 1);
-              break;
+          // Remove the file from the element.
+          if (currentValue.length) {
+            var fileNames = currentValue.split(';');
+            for (var i in fileNames) {
+              if (fileNames[i] === file.processedName) {
+                fileNames.splice(i, 1);
+                break;
+              }
             }
+
+            var newValue = fileNames.join(';');
+            uploadedFilesElement.attr('value', newValue);
           }
+        });
 
-          var newValue = fileNames.join(';');
-          uploadedFilesElement.attr('value', newValue);
-        }
-      });
-
-      // React on maxfilesexceeded. Remove all rejected files.
-      dropzoneInstance.on('maxfilesexceeded', function () {
-        var rejectedFiles = dropzoneInstance.getRejectedFiles();
-        for (var i = 0; i < rejectedFiles.length; i++) {
-          dropzoneInstance.removeFile(rejectedFiles[i]);
-        }
+        // React on maxfilesexceeded. Remove all rejected files.
+        dropzoneInstance.on('maxfilesexceeded', function () {
+          var rejectedFiles = dropzoneInstance.getRejectedFiles();
+          for (var i = 0; i < rejectedFiles.length; i++) {
+            dropzoneInstance.removeFile(rejectedFiles[i]);
+          }
+        });
       });
     }
   };

--- a/modules/eb_widget/config/schema/dropzonejs_eb_widget.schema.yml
+++ b/modules/eb_widget/config/schema/dropzonejs_eb_widget.schema.yml
@@ -3,7 +3,7 @@ entity_browser.browser.widget.dropzonejs:
   label: 'DropzoneJS widget configuration'
   mapping:
     submit_text:
-      type: string
+      type: text
       label: 'Submit button text'
     auto_select:
       type: boolean
@@ -12,7 +12,7 @@ entity_browser.browser.widget.dropzonejs:
       type: string
       label: 'Upload location'
     dropzone_description:
-      type: string
+      type: text
       label: 'Dropzone drag-n-drop zone text'
     max_filesize:
       type: string

--- a/modules/eb_widget/dropzonejs_eb_widget.info.yml
+++ b/modules/eb_widget/dropzonejs_eb_widget.info.yml
@@ -1,7 +1,7 @@
 name: DropzoneJS entity browser widget
 type: module
 description: DropzoneJS Entity browser widget
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 package: Media
 dependencies:
   - drupal:file

--- a/modules/eb_widget/dropzonejs_eb_widget.info.yml
+++ b/modules/eb_widget/dropzonejs_eb_widget.info.yml
@@ -1,6 +1,6 @@
 name: DropzoneJS entity browser widget
 type: module
-description: DropzoneJS Entity browser widget
+description: 'DropzoneJS Entity browser widget.'
 core_version_requirement: ^8.8 || ^9
 package: Media
 dependencies:

--- a/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
+++ b/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
@@ -603,4 +603,18 @@ class DropzoneJsEbWidget extends WidgetBase {
     return $ajax;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function handleWidgetContext($widget_context) {
+    parent::handleWidgetContext($widget_context);
+    $validators = isset($widget_context['upload_validators']) ? $widget_context['upload_validators'] : [];
+    if (isset($validators['file_validate_size'])) {
+      $this->configuration['max_filesize'] = $validators['file_validate_size'][0];
+    }
+    if (isset($validators['file_validate_extensions'])) {
+      $this->configuration['extensions'] = $validators['file_validate_extensions'][0];
+    }
+  }
+
 }

--- a/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
+++ b/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
@@ -14,6 +14,7 @@ use Drupal\Core\Utility\Token;
 use Drupal\dropzonejs\DropzoneJsUploadSaveInterface;
 use Drupal\entity_browser\WidgetBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Asset\LibraryDiscoveryInterface;
 
 /**
  * Provides an Entity Browser widget that uploads new files.
@@ -56,6 +57,13 @@ class DropzoneJsEbWidget extends WidgetBase {
   protected $fileSystem;
 
   /**
+   * The library discovery service.
+   *
+   * @var \Drupal\Core\Asset\LibraryDiscoveryInterface
+   */
+  protected $libraryDiscovery;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
@@ -64,6 +72,7 @@ class DropzoneJsEbWidget extends WidgetBase {
     $widget->setCurrentUser($container->get('current_user'));
     $widget->setToken($container->get('token'));
     $widget->setFileSystem($container->get('file_system'));
+    $widget->setLibraryDiscovery($container->get('library.discovery'));
 
     return $widget;
   }
@@ -106,6 +115,16 @@ class DropzoneJsEbWidget extends WidgetBase {
    */
   protected function setFileSystem(FileSystemInterface $fileSystem) {
     $this->fileSystem = $fileSystem;
+  }
+
+  /**
+   * Set the Library Discovery service.
+   *
+   * @param \Drupal\Core\Asset\LibraryDiscoveryInterface $library_discovery
+   *   The library discovery service.
+   */
+  protected function setLibraryDiscovery(LibraryDiscoveryInterface $library_discovery) {
+    $this->libraryDiscovery = $library_discovery;
   }
 
   /**
@@ -391,7 +410,7 @@ class DropzoneJsEbWidget extends WidgetBase {
     ];
 
 
-    $exif_found = \Drupal::service('library.discovery')->getLibraryByName('dropzonejs', 'exif-js');
+    $exif_found = $this->libraryDiscovery->getLibraryByName('dropzonejs', 'exif-js');
 
     $form['clientside_resize'] = [
       '#type' => 'checkbox',

--- a/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
+++ b/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
@@ -262,7 +262,7 @@ class DropzoneJsEbWidget extends WidgetBase {
     // it's still better not to rely only on client side validation.
     if (($trigger['#type'] == 'submit' && $trigger['#name'] == 'op') || $trigger['#name'] === 'auto_select_handler') {
       $upload_location = $this->getUploadLocation();
-      if (!$this->fileSystem->prepareDirectory($upload_location, FileSystemInterface::MODIFY_PERMISSIONS)) {
+      if (!$this->fileSystem->prepareDirectory($upload_location, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
         $form_state->setError($form['widget']['upload'], $this->t('Files could not be uploaded because the destination directory %destination is not configured correctly.', ['%destination' => $this->getConfiguration()['settings']['upload_location']]));
       }
 

--- a/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
+++ b/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
@@ -7,16 +7,13 @@ use Drupal\Component\Utility\Environment;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\InvokeCommand;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Utility\Token;
 use Drupal\dropzonejs\DropzoneJsUploadSaveInterface;
 use Drupal\entity_browser\WidgetBase;
-use Drupal\entity_browser\WidgetValidationManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Provides an Entity Browser widget that uploads new files.
@@ -59,51 +56,56 @@ class DropzoneJsEbWidget extends WidgetBase {
   protected $fileSystem;
 
   /**
-   * Constructs widget plugin.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
-   *   Event dispatcher service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\entity_browser\WidgetValidationManager $validation_manager
-   *   The Widget Validation Manager service.
-   * @param \Drupal\dropzonejs\DropzoneJsUploadSaveInterface $dropzonejs_upload_save
-   *   The upload saving dropzonejs service.
-   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
-   *   The current user service.
-   * @param \Drupal\Core\Utility\Token $token
-   *   The token service.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EventDispatcherInterface $event_dispatcher, EntityTypeManagerInterface $entity_type_manager, WidgetValidationManager $validation_manager, DropzoneJsUploadSaveInterface $dropzonejs_upload_save, AccountProxyInterface $current_user, Token $token, FileSystemInterface $fileSystem) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $event_dispatcher, $entity_type_manager, $validation_manager);
-    $this->dropzoneJsUploadSave = $dropzonejs_upload_save;
-    $this->currentUser = $current_user;
-    $this->token = $token;
-    $this->fileSystem = $fileSystem;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('event_dispatcher'),
-      $container->get('entity_type.manager'),
-      $container->get('plugin.manager.entity_browser.widget_validation'),
-      $container->get('dropzonejs.upload_save'),
-      $container->get('current_user'),
-      $container->get('token'),
-      $container->get('file_system')
-    );
+    $widget = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $widget->setDropzoneJsUploadSave($container->get('dropzonejs.upload_save'));
+    $widget->setCurrentUser($container->get('current_user'));
+    $widget->setToken($container->get('token'));
+    $widget->setFileSystem($container->get('file_system'));
+
+    return $widget;
+  }
+
+  /**
+   * Set the upload saving dropzonejs service.
+   *
+   * @param \Drupal\dropzonejs\DropzoneJsUploadSaveInterface $dropzoneJsUploadSave
+   *   The upload saving dropzonejs service.
+   */
+  protected function setDropzoneJsUploadSave(DropzoneJsUploadSaveInterface $dropzoneJsUploadSave) {
+    $this->dropzoneJsUploadSave = $dropzoneJsUploadSave;
+  }
+
+  /**
+   * Set the current user service.
+   *
+   * @param \Drupal\Core\Session\AccountProxyInterface $currentUser
+   *   The current user service.
+   */
+  protected function setCurrentUser(AccountProxyInterface $currentUser) {
+    $this->currentUser = $currentUser;
+  }
+
+  /**
+   * Set the token service.
+   *
+   * @param \Drupal\Core\Utility\Token $token
+   *   The token service.
+   */
+  protected function setToken(Token $token) {
+    $this->token = $token;
+  }
+
+  /**
+   * Set the filesystem service.
+   *
+   * @param \Drupal\Core\File\FileSystemInterface $fileSystem
+   *   The filesystem service.
+   */
+  protected function setFileSystem(FileSystemInterface $fileSystem) {
+    $this->fileSystem = $fileSystem;
   }
 
   /**

--- a/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
+++ b/modules/eb_widget/src/Plugin/EntityBrowser/Widget/DropzoneJsEbWidget.php
@@ -226,7 +226,9 @@ class DropzoneJsEbWidget extends WidgetBase {
           $this->currentUser,
           $additional_validators
         );
-        $files[] = $entity;
+        if ($entity) {
+          $files[] = $entity;
+        }
       }
     }
 

--- a/modules/eb_widget/src/Plugin/EntityBrowser/Widget/InlineEntityFormMediaWidget.php
+++ b/modules/eb_widget/src/Plugin/EntityBrowser/Widget/InlineEntityFormMediaWidget.php
@@ -3,20 +3,13 @@
 namespace Drupal\dropzonejs_eb_widget\Plugin\EntityBrowser\Widget;
 
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
-use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\Utility\Token;
-use Drupal\dropzonejs\DropzoneJsUploadSaveInterface;
 use Drupal\dropzonejs\Events\DropzoneMediaEntityCreateEvent;
 use Drupal\dropzonejs\Events\Events;
 use Drupal\entity_browser\WidgetBase;
-use Drupal\entity_browser\WidgetValidationManager;
 use Drupal\inline_entity_form\Element\InlineEntityForm;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Provides an Entity Browser widget that uploads and edit new files.
@@ -38,52 +31,23 @@ class InlineEntityFormMediaWidget extends MediaEntityDropzoneJsEbWidget {
   protected $entityDisplayRepository;
 
   /**
-   * Constructs widget plugin.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
-   *   Event dispatcher service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\entity_browser\WidgetValidationManager $validation_manager
-   *   The Widget Validation Manager service.
-   * @param \Drupal\dropzonejs\DropzoneJsUploadSaveInterface $dropzonejs_upload_save
-   *   The upload saving dropzonejs service.
-   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
-   *   The current user service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler service.
-   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository
-   *   The entity display repository service.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EventDispatcherInterface $event_dispatcher, EntityTypeManagerInterface $entity_type_manager, WidgetValidationManager $validation_manager, DropzoneJsUploadSaveInterface $dropzonejs_upload_save, AccountProxyInterface $current_user, Token $token, ModuleHandlerInterface $module_handler, EntityDisplayRepositoryInterface $entity_display_repository) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $event_dispatcher, $entity_type_manager, $validation_manager, $dropzonejs_upload_save, $current_user, $token, $module_handler);
-
-    $this->entityDisplayRepository = $entity_display_repository;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('event_dispatcher'),
-      $container->get('entity_type.manager'),
-      $container->get('plugin.manager.entity_browser.widget_validation'),
-      $container->get('dropzonejs.upload_save'),
-      $container->get('current_user'),
-      $container->get('token'),
-      $container->get('module_handler'),
-      $container->get('entity_display.repository')
-    );
+    $widget = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $widget->setEntityDisplayRepository($container->get('entity_display.repository'));
+
+    return $widget;
+  }
+
+  /**
+   * Set the entity display repository service.
+   *
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entityDisplayRepository
+   *   The entity display repository service.
+   */
+  protected function setEntityDisplayRepository(EntityDisplayRepositoryInterface $entityDisplayRepository) {
+    $this->entityDisplayRepository = $entityDisplayRepository;
   }
 
   /**

--- a/modules/eb_widget/src/Plugin/EntityBrowser/Widget/MediaEntityDropzoneJsEbWidget.php
+++ b/modules/eb_widget/src/Plugin/EntityBrowser/Widget/MediaEntityDropzoneJsEbWidget.php
@@ -2,18 +2,12 @@
 
 namespace Drupal\dropzonejs_eb_widget\Plugin\EntityBrowser\Widget;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
-use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\Utility\Token;
-use Drupal\dropzonejs\DropzoneJsUploadSaveInterface;
 use Drupal\dropzonejs\Events\DropzoneMediaEntityCreateEvent;
 use Drupal\dropzonejs\Events\Events;
-use Drupal\entity_browser\WidgetValidationManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Provides an Entity Browser widget that uploads media entities.
@@ -38,50 +32,23 @@ class MediaEntityDropzoneJsEbWidget extends DropzoneJsEbWidget {
   protected $moduleHandler;
 
   /**
-   * Constructs widget plugin.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
-   *   Event dispatcher service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\entity_browser\WidgetValidationManager $validation_manager
-   *   The Widget Validation Manager service.
-   * @param \Drupal\dropzonejs\DropzoneJsUploadSaveInterface $dropzonejs_upload_save
-   *   The upload saving dropzonejs service.
-   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
-   *   The current user service.
-   * @param Token $token
-   *   The token service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler service.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EventDispatcherInterface $event_dispatcher, EntityTypeManagerInterface $entity_type_manager, WidgetValidationManager $validation_manager, DropzoneJsUploadSaveInterface $dropzonejs_upload_save, AccountProxyInterface $current_user, Token $token, ModuleHandlerInterface $module_handler) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $event_dispatcher, $entity_type_manager, $validation_manager, $dropzonejs_upload_save, $current_user, $token);
-    $this->moduleHandler = $module_handler;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('event_dispatcher'),
-      $container->get('entity_type.manager'),
-      $container->get('plugin.manager.entity_browser.widget_validation'),
-      $container->get('dropzonejs.upload_save'),
-      $container->get('current_user'),
-      $container->get('token'),
-      $container->get('module_handler')
-    );
+    $widget = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $widget->setModuleHandler($container->get('module_handler'));
+
+    return $widget;
+  }
+
+  /**
+   * Set the module handler service.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   The module handler service.
+   */
+  protected function setModuleHandler(ModuleHandlerInterface $moduleHandler) {
+    $this->moduleHandler = $moduleHandler;
   }
 
   /**

--- a/modules/eb_widget/src/Plugin/EntityBrowser/Widget/MediaEntityDropzoneJsEbWidget.php
+++ b/modules/eb_widget/src/Plugin/EntityBrowser/Widget/MediaEntityDropzoneJsEbWidget.php
@@ -104,6 +104,11 @@ class MediaEntityDropzoneJsEbWidget extends DropzoneJsEbWidget {
       ]);
     }
 
+    // Remove these config options as these are propagated from the field.
+    $form['max_filesize']['#access'] = FALSE;
+    $form['extensions']['#access'] = FALSE;
+    $form['upload_location']['#access'] = FALSE;
+
     return $form;
   }
 
@@ -165,6 +170,20 @@ class MediaEntityDropzoneJsEbWidget extends DropzoneJsEbWidget {
 
     $this->selectEntities($media_entities, $form_state);
     $this->clearFormValues($element, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function handleWidgetContext($widget_context) {
+    parent::handleWidgetContext($widget_context);
+    $bundle = $this->getType();
+    $source = $bundle->getSource();
+    $field = $source->getSourceFieldDefinition($bundle);
+    $field_storage = $field->getFieldStorageDefinition();
+    $this->configuration['upload_location'] = $field_storage->getSettings()['uri_scheme'] . '://' . $field->getSettings()['file_directory'];
+    $this->configuration['max_filesize'] = $field->getSettings()['max_filesize'];
+    $this->configuration['extensions'] = $field->getSettings()['file_extensions'];
   }
 
 }

--- a/src/Controller/UploadController.php
+++ b/src/Controller/UploadController.php
@@ -55,7 +55,7 @@ class UploadController extends ControllerBase {
   }
 
   /**
-   * Handles DropzoneJs uploads.
+   * Handles DropzoneJS uploads.
    */
   public function handleUploads() {
     $file = $this->request->files->get('file');

--- a/src/Controller/UploadController.php
+++ b/src/Controller/UploadController.php
@@ -65,10 +65,12 @@ class UploadController extends ControllerBase {
 
     // @todo: Implement file_validate_size();
     try {
+      /* @var \Drupal\Core\File\FileSystem $file_system */
+      $file_system = \Drupal::service('file_system');
       // Return JSON-RPC response.
       return new AjaxResponse([
         'jsonrpc' => '2.0',
-        'result' => basename($this->uploadHandler->handleUpload($file)),
+        'result' => $file_system->basename($this->uploadHandler->handleUpload($file)),
         'id' => 'id',
       ]);
     }

--- a/src/DropzoneJsUploadSaveInterface.php
+++ b/src/DropzoneJsUploadSaveInterface.php
@@ -6,7 +6,7 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\file\FileInterface;
 
 /**
- * Provides an interface for classes that save DropzoneJs uploads.
+ * Provides an interface for classes that save DropzoneJS uploads.
  */
 interface DropzoneJsUploadSaveInterface {
 

--- a/src/Element/DropzoneJs.php
+++ b/src/Element/DropzoneJs.php
@@ -171,8 +171,6 @@ class DropzoneJs extends FormElement {
         $file_names = array_filter(explode(';', $user_input['uploaded_files']));
         $tmp_upload_scheme = \Drupal::configFactory()->get('dropzonejs.settings')->get('tmp_upload_scheme');
 
-        $file_names = explode(',', $file_names[0]);
-
         foreach ($file_names as $name) {
           // The upload handler appended the txt extension to the file for
           // security reasons. We will remove it in this callback.

--- a/src/Element/DropzoneJs.php
+++ b/src/Element/DropzoneJs.php
@@ -171,6 +171,8 @@ class DropzoneJs extends FormElement {
         $file_names = array_filter(explode(';', $user_input['uploaded_files']));
         $tmp_upload_scheme = \Drupal::configFactory()->get('dropzonejs.settings')->get('tmp_upload_scheme');
 
+        $file_names = explode(',', $file_names[0]);
+
         foreach ($file_names as $name) {
           // The upload handler appended the txt extension to the file for
           // security reasons. We will remove it in this callback.

--- a/src/Element/DropzoneJs.php
+++ b/src/Element/DropzoneJs.php
@@ -23,7 +23,7 @@ use Drupal\Core\Url;
  *   Will be visible inside the upload area.
  * - #max_filesize (string)
  *   Used by dropzonejs and expressed in number + unit (i.e. 1.1M) This will be
- *   converted to a form that DropzoneJs understands. See:
+ *   converted to a form that DropzoneJS understands. See:
  *   http://www.dropzonejs.com/#config-maxFilesize
  * - #extensions (string)
  *   A string of valid extensions separated by a space.

--- a/src/Element/DropzoneJs.php
+++ b/src/Element/DropzoneJs.php
@@ -138,6 +138,7 @@ class DropzoneJs extends FormElement {
           'dictDefaultMessage' => Html::escape($element['#dropzone_description']),
           'acceptedFiles' => '.' . str_replace(' ', ',.', self::getValidExtensions($element)),
           'maxFiles' => $element['#max_files'],
+          'timeout' => \Drupal::configFactory()->get('dropzonejs.settings')->get('upload_timeout_ms'),
         ],
       ],
     ];

--- a/src/UploadHandler.php
+++ b/src/UploadHandler.php
@@ -44,11 +44,11 @@ class UploadHandler implements UploadHandlerInterface {
   protected $languageManager;
 
   /**
-   * The scheme (stream wrapper) used to store uploaded files.
+   * The settings of dropzonejs.
    *
-   * @var string
+   * @var \Drupal\Core\Config\ImmutableConfig
    */
-  protected $tmpUploadScheme;
+  protected $dropzoneSettings;
 
   /**
    * Constructs dropzone upload controller route controller.
@@ -66,7 +66,7 @@ class UploadHandler implements UploadHandlerInterface {
     $this->request = $request_stack->getCurrentRequest();
     $this->transliteration = $transliteration;
     $this->languageManager = $language_manager;
-    $this->tmpUploadScheme = $config_factory->get('dropzonejs.settings')->get('tmp_upload_scheme');
+    $this->dropzoneSettings = $config_factory->get('dropzonejs.settings');
   }
 
   /**
@@ -79,6 +79,10 @@ class UploadHandler implements UploadHandlerInterface {
     // which we use to separate filenames.
     if (!isset($original_name)) {
       throw new UploadException(UploadException::FILENAME_ERROR);
+    }
+
+    if (!$this->dropzoneSettings->get('filename_transliteration')) {
+      return $original_name . '.txt';
     }
 
     // @todo The following filename sanitization steps replicate the behaviour
@@ -100,9 +104,7 @@ class UploadHandler implements UploadHandlerInterface {
     // For security reasons append the txt extension. It will be removed in
     // Drupal\dropzonejs\Element::valueCallback when we will know the valid
     // extension and we will be able to properly sanitize the filename.
-    $processed_filename = $filename . '.txt';
-
-    return $processed_filename;
+    return $filename . '.txt';
   }
 
   /**
@@ -136,7 +138,7 @@ class UploadHandler implements UploadHandlerInterface {
     }
 
     // Open temp file.
-    $tmp = $this->tmpUploadScheme . '://' . $this->getFilename($file);
+    $tmp = $this->dropzoneSettings->get('tmp_upload_scheme') . '://' . $this->getFilename($file);
     if (!($out = fopen($tmp, $this->request->request->get('chunk', 0) ? 'ab' : 'wb'))) {
       throw new UploadException(UploadException::OUTPUT_ERROR);
     }

--- a/src/UploadHandler.php
+++ b/src/UploadHandler.php
@@ -8,7 +8,6 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Drupal\Component\Utility\Unicode;
 
 /**
  * Handles files uploaded by Dropzone.
@@ -96,7 +95,7 @@ class UploadHandler implements UploadHandlerInterface {
     // Remove multiple consecutive non-alphabetical characters.
     $filename = preg_replace('/(_)_+|(\.)\.+|(-)-+/', '\\1\\2\\3', $filename);
     // Force lowercase to prevent issues on case-insensitive file systems.
-    $filename = Unicode::strtolower($filename);
+    $filename = strtolower($filename);
 
     // For security reasons append the txt extension. It will be removed in
     // Drupal\dropzonejs\Element::valueCallback when we will know the valid

--- a/src/UploadHandler.php
+++ b/src/UploadHandler.php
@@ -120,17 +120,17 @@ class UploadHandler implements UploadHandlerInterface {
         case UPLOAD_ERR_INI_SIZE:
         case UPLOAD_ERR_FORM_SIZE:
           $message = $this->t('The file could not be saved because it exceeds the maximum allowed size for uploads.');
-          continue;
+          break;
 
         case UPLOAD_ERR_PARTIAL:
         case UPLOAD_ERR_NO_FILE:
           $message = $this->t('The file could not be saved because the upload did not complete.');
-          continue;
+          break;
 
         // Unknown error.
         default:
           $message = $this->t('The file could not be saved. An unknown error has occurred.');
-          continue;
+          break;
       }
 
       throw new UploadException(UploadException::FILE_UPLOAD_ERROR, $message);

--- a/tests/modules/dropzonejs_test/config/install/core.entity_form_display.media.dropzonejs_media.default.yml
+++ b/tests/modules/dropzonejs_test/config/install/core.entity_form_display.media.dropzonejs_media.default.yml
@@ -1,0 +1,61 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.dropzonejs_media.field_media_image
+    - image.style.thumbnail
+    - media.type.dropzonejs_media
+  module:
+    - image
+    - path
+id: media.dropzonejs_media.default
+targetEntityType: media
+bundle: dropzonejs_media
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_image:
+    weight: 0
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/tests/modules/dropzonejs_test/config/install/core.entity_form_display.node.dropzonejs_test.default.yml
+++ b/tests/modules/dropzonejs_test/config/install/core.entity_form_display.node.dropzonejs_test.default.yml
@@ -1,0 +1,82 @@
+uuid: cc12d4b9-9cb9-43d3-b92a-b6106b6df5f1
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.dropzonejs_eb_test
+    - field.field.node.dropzonejs_test.field_dropzonejs_image
+    - node.type.dropzonejs_test
+  module:
+    - entity_browser
+    - path
+id: node.dropzonejs_test.default
+targetEntityType: node
+bundle: dropzonejs_test
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_dropzonejs_image:
+    weight: 1
+    settings:
+      entity_browser: dropzonejs_eb_test
+      field_widget_display: label
+      open: true
+      selection_mode: selection_append
+      field_widget_edit: false
+      field_widget_remove: false
+      field_widget_replace: false
+      field_widget_display_settings: {  }
+    third_party_settings: {  }
+    type: entity_browser_entity_reference
+    region: content
+  path:
+    type: path
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 4
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 7
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 5
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 2
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/tests/modules/dropzonejs_test/config/install/core.entity_view_display.media.dropzonejs_media.default.yml
+++ b/tests/modules/dropzonejs_test/config/install/core.entity_view_display.media.dropzonejs_media.default.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.dropzonejs_media.field_media_image
+    - image.style.large
+    - media.type.dropzonejs_media
+  module:
+    - image
+id: media.dropzonejs_media.default
+targetEntityType: media
+bundle: dropzonejs_media
+mode: default
+content:
+  field_media_image:
+    label: visually_hidden
+    weight: 0
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/tests/modules/dropzonejs_test/config/install/core.entity_view_display.node.dropzonejs_test.default.yml
+++ b/tests/modules/dropzonejs_test/config/install/core.entity_view_display.node.dropzonejs_test.default.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.dropzonejs_test.field_dropzonejs_image
+    - node.type.dropzonejs_test
+  module:
+    - user
+id: node.dropzonejs_test.default
+targetEntityType: node
+bundle: dropzonejs_test
+mode: default
+content:
+  field_dropzonejs_image:
+    type: entity_reference_entity_view
+    weight: 101
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/tests/modules/dropzonejs_test/config/install/entity_browser.browser.dropzonejs_eb_test.yml
+++ b/tests/modules/dropzonejs_test/config/install/entity_browser.browser.dropzonejs_eb_test.yml
@@ -1,0 +1,40 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.dropzonejs_media
+  module:
+    - dropzonejs_eb_widget
+    - media
+name: dropzonejs_eb_test
+label: 'Dropzonejs eb test'
+display: iframe
+display_configuration:
+  width: '650'
+  height: '500'
+  link_text: 'Select entities'
+  auto_open: false
+selection_display: no_display
+selection_display_configuration: {  }
+widget_selector: single
+widget_selector_configuration: {  }
+widgets:
+  44b1e6ea-637d-4dd6-b79e-edeefc546c1c:
+    settings:
+      media_type: dropzonejs_media
+      upload_location: 'public://'
+      dropzone_description: 'Drop files here to upload them'
+      max_filesize: 2M
+      extensions: 'jpg jpeg gif png txt doc xls pdf ppt pps odt ods odp'
+      clientside_resize: false
+      resize_width: null
+      resize_height: null
+      resize_quality: !!float 1
+      resize_method: contain
+      thumbnail_method: contain
+      submit_text: 'Select entities'
+      auto_select: false
+    uuid: 44b1e6ea-637d-4dd6-b79e-edeefc546c1c
+    weight: 2
+    label: 'Dropzonejs media'
+    id: dropzonejs_media_entity

--- a/tests/modules/dropzonejs_test/config/install/field.field.media.dropzonejs_media.field_media_image.yml
+++ b/tests/modules/dropzonejs_test/config/install/field.field.media.dropzonejs_media.field_media_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_image
+    - media.type.dropzonejs_media
+  module:
+    - image
+id: media.dropzonejs_media.field_media_image
+field_name: field_media_image
+entity_type: media
+bundle: dropzonejs_media
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/tests/modules/dropzonejs_test/config/install/field.field.node.dropzonejs_test.field_dropzonejs_image.yml
+++ b/tests/modules/dropzonejs_test/config/install/field.field.node.dropzonejs_test.field_dropzonejs_image.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_dropzonejs_image
+    - media.type.dropzonejs_media
+    - node.type.dropzonejs_test
+id: node.dropzonejs_test.field_dropzonejs_image
+field_name: field_dropzonejs_image
+entity_type: node
+bundle: dropzonejs_test
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      dropzonejs_media: dropzonejs_media
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/tests/modules/dropzonejs_test/config/install/field.storage.media.field_media_image.yml
+++ b/tests/modules/dropzonejs_test/config/install/field.storage.media.field_media_image.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - media
+  module:
+    - file
+    - image
+    - media
+_core:
+  default_config_hash: 7ZBrcl87ZXaw42v952wwcw_9cQgTBq5_5tgyUkE-VV0
+id: media.field_media_image
+field_name: field_media_image
+entity_type: media
+type: image
+settings:
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/dropzonejs_test/config/install/field.storage.node.field_dropzonejs_image.yml
+++ b/tests/modules/dropzonejs_test/config/install/field.storage.node.field_dropzonejs_image.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_dropzonejs_image
+field_name: field_dropzonejs_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/modules/dropzonejs_test/config/install/media.type.dropzonejs_media.yml
+++ b/tests/modules/dropzonejs_test/config/install/media.type.dropzonejs_media.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies: {  }
+id: dropzonejs_media
+label: 'Dropzonejs media'
+description: ''
+source: image
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_image
+field_map: {  }

--- a/tests/modules/dropzonejs_test/config/install/node.type.dropzonejs_test.yml
+++ b/tests/modules/dropzonejs_test/config/install/node.type.dropzonejs_test.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: 'Dropzonejs test'
+type: dropzonejs_test
+description: ''
+help: ''
+new_revision: false
+preview_mode: 0
+display_submitted: false

--- a/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
+++ b/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
@@ -3,7 +3,6 @@ type: module
 description: 'Support module for DropzoneJs tests.'
 package: Testing
 version: VERSION
-core: 8.x
 dependencies:
  - drupal:media
  - dropzonejs:dropzonejs

--- a/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
+++ b/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
@@ -1,6 +1,6 @@
-name: 'DropzoneJs Test'
+name: 'DropzoneJS Test'
 type: module
-description: 'Support module for DropzoneJs tests.'
+description: 'Support module for DropzoneJS tests.'
 package: Testing
 version: VERSION
 dependencies:

--- a/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
+++ b/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
@@ -1,6 +1,7 @@
 name: 'DropzoneJS Test'
 type: module
 description: 'Support module for DropzoneJS tests.'
+core_version_requirement: ^8.8 || ^9
 package: Testing
 version: VERSION
 dependencies:

--- a/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
+++ b/tests/modules/dropzonejs_test/dropzonejs_test.info.yml
@@ -5,4 +5,6 @@ package: Testing
 version: VERSION
 core: 8.x
 dependencies:
+ - drupal:media
  - dropzonejs:dropzonejs
+ - dropzonejs:dropzonejs_eb_widget

--- a/tests/modules/dropzonejs_test/src/Form/DropzoneJsTestForm.php
+++ b/tests/modules/dropzonejs_test/src/Form/DropzoneJsTestForm.php
@@ -22,10 +22,10 @@ class DropzoneJsTestForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form['dropzonejs'] = [
-      '#title' => $this->t('DropzoneJs element'),
+      '#title' => $this->t('DropzoneJS element'),
       '#type' => 'dropzonejs',
       '#required' => TRUE,
-      '#dropzone_description' => 'DropzoneJs description',
+      '#dropzone_description' => 'DropzoneJS description',
       '#max_filesize' => '1M',
       '#extensions' => 'jpg png',
     ];

--- a/tests/src/FunctionalJavascript/DropzoneJsEbWidgetTest.php
+++ b/tests/src/FunctionalJavascript/DropzoneJsEbWidgetTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\Tests\dropzonejs\FunctionalJavascript;
+
+use Drupal\Tests\field_ui\Traits\FieldUiTestTrait;
+
+/**
+ * Test dropzonejs EB Widget.
+ *
+ * @group dropzonejs
+ */
+class DropzoneJsEbWidgetTest extends DropzoneJsWebDriverTestBase {
+
+  use FieldUiTestTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'node',
+    'media',
+    'menu_ui',
+    'path',
+    'dropzonejs_test',
+  ];
+
+  /**
+   * Permissions for user that will be logged-in for test.
+   *
+   * @var array
+   */
+  protected static $userPermissions = [
+    'access dropzonejs_eb_test entity browser pages',
+    'create dropzonejs_test content',
+    'dropzone upload files',
+    'access content',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $account = $this->drupalCreateUser(static::$userPermissions);
+    $this->drupalLogin($account);
+  }
+
+  /**
+   * Tests the add widget with iframe form.
+   */
+  public function testUploadFile() {
+    $this->drupalGet('node/add/dropzonejs_test');
+    $this->getSession()->getPage()->clickLink('Select entities');
+    $this->waitForAjaxToFinish();
+    $this->getSession()->switchToIFrame('entity_browser_iframe_dropzonejs_eb_test');
+    $this->dropFile();
+    $this->waitForAjaxToFinish();
+    $this->getSession()->getPage()->pressButton('Select entities');
+
+    // Switch back to the main page.
+    $this->getSession()->switchToIFrame();
+    $this->waitForAjaxToFinish();
+    // For some reason we have to wait here for the markup to show up regardless
+    // of the waitForAjaxToFinish above.
+    sleep(2);
+    $this->assertSession()->elementContains('xpath', '//div[contains(@class, "entities-list")]/div[contains(@class, "label")]', 'notalama.jpg');
+  }
+}

--- a/tests/src/FunctionalJavascript/DropzoneJsWebDriverTestBase.php
+++ b/tests/src/FunctionalJavascript/DropzoneJsWebDriverTestBase.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\Tests\dropzonejs\FunctionalJavascript;
+
+use Drupal\file\Entity\File;
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+
+/**
+ * Base class for DropzoneJS Web driver functional test base.
+ *
+ * @package Drupal\Tests\entity_browser\FunctionalJavascript
+ */
+abstract class DropzoneJsWebDriverTestBase extends WebDriverTestBase {
+
+  protected $defaultTheme = 'classy';
+
+  /**
+   * Simple grey rectangle image data.
+   *
+   * @var string
+   */
+  var $fileData = "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAAAAABVicqIAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA
+B3RJTUUH3gIYBAEMHCkuWQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUH
+AAAAQElEQVRo3u3NQQ0AAAgEoNN29i9kCh9uUICa3OtIJBKJRCKRSCQSiUQikUgkEolEIpFIJBKJ
+RCKRSCQSiUTyPlnSFQER9VCp/AAAAABJRU5ErkJggg==";
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'dropzonejs_test',
+    'views',
+    'block',
+    'node',
+    'file',
+    'image',
+    'field_ui',
+    'views_ui',
+    'system',
+  ];
+
+  /**
+   * Creates an file.
+   *
+   * @param string $name
+   *   The name of the image.
+   * @param string $extension
+   *   File extension.
+   *
+   * @return \Drupal\file\FileInterface
+   *   Returns an image.
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function getFile($name, $extension = 'jpg') {
+    file_put_contents('public://' . $name . '.' . $extension, $this->fileData);
+
+    $file = File::create([
+      'filename' => $name . '.' . $extension,
+      'uri' => 'public://' . $name . '.' . $extension,
+    ]);
+    $file->setPermanent();
+    $file->save();
+
+    return $file;
+  }
+
+  /**
+   * Waits for jQuery to become ready and animations to complete.
+   */
+  protected function waitForAjaxToFinish() {
+    $this->assertSession()->assertWaitOnAjaxRequest();
+  }
+
+  /**
+   * Drop a predefined file to dropzone.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function dropFile() {
+    // Sometimes we are not yet switched to the iframe. Stop the horses a bit
+    // here.
+    sleep(1);
+    $file = $this->getFile('notalama');
+
+    $input = <<<JS
+      jQuery('.form-type-dropzonejs').append('<input type=\'file\' name=\'fakefile\'>');
+JS;
+    $this->getSession()->evaluateScript($input);
+
+    $full_path = \Drupal::service('file_system')->realPath($file->getFileUri());
+    if (is_file($full_path)) {
+      $path = $full_path;
+    }
+
+    if (!isset($path) || !file_exists($path)) {
+      throw new \RuntimeException("File $path does not exist");
+    }
+
+    $this->getSession()->getPage()->attachFileToField('fakefile', $path);
+
+    $drop = <<<JS
+    (function(jQuery) {
+      var fakeFileInputs = jQuery('input[name=fakefile]' );
+      var fileList = fakeFileInputs.map(function (i, el) { return el.files[0] });
+      var e = jQuery.Event('drop', { dataTransfer : { files : fileList } });
+      jQuery('.dropzone' )[0].dropzone.listeners[0].events.drop(e);
+      fakeFileInputs.map(function (i, el) { return el.remove(); });
+    })(jQuery);
+JS;
+
+    $this->getSession()->evaluateScript($drop);
+  }
+
+}

--- a/tests/src/Kernel/DropzoneJsElementTest.php
+++ b/tests/src/Kernel/DropzoneJsElementTest.php
@@ -31,7 +31,6 @@ class DropzoneJsElementTest extends KernelTestBase {
    */
   protected function setUp() {
     parent::setUp();
-    $this->installSchema('system', 'router');
     $this->installEntitySchema('user');
 
     /** @var \Drupal\user\RoleInterface $role */
@@ -50,17 +49,17 @@ class DropzoneJsElementTest extends KernelTestBase {
 
     $xpath_base = "//div[contains(@class, 'form-item-dropzonejs')]";
     // Label.
-    $this->assertFalse($this->xpath("$xpath_base/label[text()='Not DropzoneJs element']"));
-    $this->assertTrue($this->xpath("$xpath_base/label[text()='DropzoneJs element']"));
+    $this->assertEmpty($this->xpath("$xpath_base/label[text()='Not DropzoneJs element']"));
+    $this->assertNotEmpty($this->xpath("$xpath_base/label[text()='DropzoneJs element']"));
     // Element where dropzonejs is attached to.
-    $this->assertTrue($this->xpath("$xpath_base/div[contains(@class, 'dropzone-enable')]"));
+    $this->assertNotEmpty($this->xpath("$xpath_base/div[contains(@class, 'dropzone-enable')]"));
     // Uploaded files input.
-    $this->assertTrue($this->xpath("$xpath_base/input[contains(@data-drupal-selector, 'edit-dropzonejs-uploaded-files')]"));
+    $this->assertNotEmpty($this->xpath("$xpath_base/input[contains(@data-drupal-selector, 'edit-dropzonejs-uploaded-files')]"));
     // Upload files path.
-    $this->assertTrue($this->xpath("$xpath_base/input[contains(@data-upload-path, '/dropzonejs/upload?token=')]"));
+    $this->assertNotEmpty($this->xpath("$xpath_base/input[contains(@data-upload-path, '/dropzonejs/upload?token=')]"));
     // Js is attached.
-    $this->assertTrue($this->xpath("/html/body/script[contains(@src, 'libraries/dropzone/dist/min/dropzone.min.js')]"));
-    $this->assertTrue($this->xpath("/html/body/script[contains(@src, 'dropzonejs/js/dropzone.integration.js')]"));
+    $this->assertNotEmpty($this->xpath("/html/body/script[contains(@src, 'libraries/dropzone/dist/min/dropzone.min.js')]"));
+    $this->assertNotEmpty($this->xpath("/html/body/script[contains(@src, 'dropzonejs/js/dropzone.integration.js')]"));
   }
 
 }

--- a/tests/src/Kernel/DropzoneJsElementTest.php
+++ b/tests/src/Kernel/DropzoneJsElementTest.php
@@ -7,9 +7,9 @@ use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 
 /**
- * Tests related to the dropzoneJs element.
+ * Tests related to the DropzoneJS element.
  *
- * @group DropzoneJs
+ * @group dropzonejs
  */
 class DropzoneJsElementTest extends KernelTestBase {
 
@@ -49,8 +49,8 @@ class DropzoneJsElementTest extends KernelTestBase {
 
     $xpath_base = "//div[contains(@class, 'form-item-dropzonejs')]";
     // Label.
-    $this->assertEmpty($this->xpath("$xpath_base/label[text()='Not DropzoneJs element']"));
-    $this->assertNotEmpty($this->xpath("$xpath_base/label[text()='DropzoneJs element']"));
+    $this->assertEmpty($this->xpath("$xpath_base/label[text()='Not DropzoneJS element']"));
+    $this->assertNotEmpty($this->xpath("$xpath_base/label[text()='DropzoneJS element']"));
     // Element where dropzonejs is attached to.
     $this->assertNotEmpty($this->xpath("$xpath_base/div[contains(@class, 'dropzone-enable')]"));
     // Uploaded files input.

--- a/tests/src/Kernel/DropzoneJsUploadControllerTest.php
+++ b/tests/src/Kernel/DropzoneJsUploadControllerTest.php
@@ -11,9 +11,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Drupal\language\Entity\ConfigurableLanguage;
 
 /**
- * Tests dropzoneJs upload controller.
+ * Tests DropzoneJS upload controller.
  *
- * @group DropzoneJs
+ * @group dropzonejs
  */
 class DropzoneJsUploadControllerTest extends KernelTestBase {
 
@@ -43,7 +43,7 @@ class DropzoneJsUploadControllerTest extends KernelTestBase {
    *
    * @var string
    */
-  protected $testfileData = 'DropzoneJs test file data';
+  protected $testfileData = 'DropzoneJS test file data';
 
   /**
    * Modules to enable.
@@ -68,7 +68,7 @@ class DropzoneJsUploadControllerTest extends KernelTestBase {
   }
 
   /**
-   * Test that dropzoneJs correctly handles uploads.
+   * Test that DropzoneJS correctly handles uploads.
    */
   public function testDropzoneJsUploadController() {
     $this->container->get('router.builder')->rebuild();
@@ -99,7 +99,7 @@ class DropzoneJsUploadControllerTest extends KernelTestBase {
   }
 
   /**
-   * Tests that dropzoneJs ignores filename transliteration.
+   * Tests that DropzoneJS ignores filename transliteration.
    */
   public function testIgnoreTransliteration() {
     $this->container->get('router.builder')->rebuild();

--- a/tests/src/Kernel/DropzoneJsUploadControllerTest.php
+++ b/tests/src/Kernel/DropzoneJsUploadControllerTest.php
@@ -57,15 +57,11 @@ class DropzoneJsUploadControllerTest extends KernelTestBase {
    */
   protected function setUp() {
     parent::setUp();
-    $this->installSchema('system', 'router');
     $this->installConfig('dropzonejs');
     $this->installEntitySchema('user');
 
     $this->filesDir = $this->siteDirectory . '/files';
-    $config = $this->container->get('config.factory');
-    $config->getEditable('system.file')
-      ->set('path.temporary', $this->filesDir)
-      ->save();
+    $this->setSetting('file_temp_path', $this->filesDir);
 
     $this->tmpFile = tempnam('', $this->testfilePrefix);
     file_put_contents($this->tmpFile, $this->testfileData);
@@ -93,12 +89,12 @@ class DropzoneJsUploadControllerTest extends KernelTestBase {
     $upload_handler = $this->container->get('dropzonejs.upload_handler');
     $controller = new UploadController($upload_handler, $request);
     $controller_result = $controller->handleUploads();
-    $this->assertTrue($controller_result instanceof JsonResponse);
+    $this->assertInstanceOf(JsonResponse::class, $controller_result);
 
     $result = json_decode($controller_result->getContent());
     $result_file = $this->filesDir . '/' . $result->result;
     $this->assertStringEndsWith('-kaplya_aa1.jpg.txt', $result_file);
-    $this->assertTrue(file_exists($result_file));
+    $this->assertFileExists($result_file);
     $this->assertEquals(file_get_contents($result_file), $this->testfileData);
   }
 


### PR DESCRIPTION
Updates the version of dropzonejs to 2.4, then merges our patches. Command history:

```
$ git remote -v
drupal  git@git.drupal.org:project/dropzonejs.git (fetch)
drupal  git@git.drupal.org:project/dropzonejs.git (push)
origin  git@github.com:nbc-bravo/drupal-dropzonejs.git (fetch)
origin  git@github.com:nbc-bravo/drupal-dropzonejs.git (push)
$ git fetch origin
$ git fetch drupal
$ git checkout 8.x-2.4
$ git merge patched
$ git checkout -b dropzonejs-update-8.x-2.4
$ git push origin dropzonejs-update-8.x-2.4
```